### PR TITLE
Rename go imports

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -5,7 +5,7 @@ package main
 import (
 	"encoding/json"
 
-	"github.com/MaxiMobility/linode"
+	"github.com/cabify/linode"
 )
 
 func newInventory(nodes map[int]*linodeWithIPs) *inventory {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/MaxiMobility/linode"
+	"github.com/cabify/linode"
 
 	"gopkg.in/gcfg.v1"
 )

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/MaxiMobility/linode"
 
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 )
 
 const configName = "linode-inventory.ini"


### PR DESCRIPTION
cc6c812 is not really needed, since Github takes care of redirection.

```diff
-	"github.com/MaxiMobility/linode"
+	"github.com/cabify/linode"
```

But 78f4550 solves this issue:

```
➜  ~ export GOPATH=`mktemp -d /tmp/gopath.XXXXXXXX`
➜  ~ go get github.com/cabify/linode-inventory


package code.google.com/p/gcfg: unrecognized import path "code.google.com/p/gcfg" (parse https://code.google.com/p/gcfg?go-get=1: no go-import meta tags ())
➜  ~
```

`code.google.com/p/gcfg` was migrated to `gopkg.in/gcfg.v1`. See https://code.google.com/archive/p/gcfg/ for reference.

WDYT @samlown ?
